### PR TITLE
Remove Forward Slash in Menu

### DIFF
--- a/header.php
+++ b/header.php
@@ -41,7 +41,7 @@
         <hgroup>
           <h1><a href="<?php echo base_url(); ?>"><?php echo site_name(); ?></a></h1>
         </hgroup>
-        <a href="#nav" class="menu"><img src="<?php echo theme_url(); ?>/img/menu.png"></a>
+        <a href="#nav" class="menu"><img src="<?php echo theme_url(); ?>img/menu.png"></a>
         <?php if(has_menu_items()): ?>
         <nav role="navigation">
           <ul>


### PR DESCRIPTION
Removed a forward slash in a portion of the menu Nav that causes menu.png to 404.

`echo theme_url()` produces a url that ends in a `/`.

Removing the `/` before `img/menu.png` stops `menu.png` from 404'ing on page load.
